### PR TITLE
Corretto typo

### DIFF
--- a/module01/README.md
+++ b/module01/README.md
@@ -8,7 +8,7 @@ Concetti in questo modulo:
 ## Eseguiamo il nostro primo container
 Bando alla ciance, la cosa migliore è sporcarci le mani con "Hello World"!
 ```bash
-bom@princesspenny ~ $ docker container run hello-world
+bom@princesspenny ~ $ docker run hello-world
 ```
 Yeah! il nostro primo container saluta il mondo :-)
 


### PR DESCRIPTION
Credo che ci sia un typo, la parola container sembrava di troppo.
C'era scritto:
     docker container run hello-world

Ho tolto "container":
     docker run hello-world

Ciao